### PR TITLE
Add how to search by grepping for struct

### DIFF
--- a/gotchas-and-faq.rst
+++ b/gotchas-and-faq.rst
@@ -30,7 +30,7 @@ These "GTY" markers are annotations to the types, and are used by GCC's
 garbage-collector.  They're stripped away by the preprocessor when building
 GCC itself, but get used by a tool during the build called ``gengtype``.
 
-TODO: how to search for them?
+how to search for them? find . -name "*.h" | xargs grep cp_token
 
 
 How do I debug GCC?


### PR DESCRIPTION
Hi David,

Thanks for your help! for example: taught me how to migrate GGC https://gcc.gnu.org/ml/gcc/2017-07/msg00202.html

I am migrating dragonegg to GCC v6.x, so I have to grep for struct `foo`, I just use:

```
$ find . -name "*.h" | xargs grep foo
```

in the gcc-6.3.0/gcc directory. hope it works for GCC Newbies :)

Regards,
Leslie Zhai - a LLVM developer https://reviews.llvm.org/p/xiangzhai/