### PR TITLE
Fix typo in `inside-cc1.rst`

### DIFF
--- a/inside-cc1.rst
+++ b/inside-cc1.rst
@@ -388,7 +388,7 @@ the "gimplifier" has flattened:
 
   (b - c) * d
 
-into assignments to two tempories (named ``_1`` and ``D.1938``):
+into assignments to two temporaries (named ``_1`` and ``D.1938``):
 
 .. code-block:: c
 


### PR DESCRIPTION
./inside-cc1.rst:391: tempories ==> temporaries